### PR TITLE
Fix prompt about language model already existing

### DIFF
--- a/Source/RuntimeSpeechRecognizerEditor/Private/RuntimeSpeechRecognizerEditor.cpp
+++ b/Source/RuntimeSpeechRecognizerEditor/Private/RuntimeSpeechRecognizerEditor.cpp
@@ -129,6 +129,13 @@ TFuture<bool> FRuntimeSpeechRecognizerEditorModule::SetupLanguageModel() const
 	FString PackagePath = SpeechRecognizerSettings->GetLanguageModelPackagePath();
 	FString AssetPath = SpeechRecognizerSettings->GetLanguageModelAssetPath();
 
+	const FString LanguageModelAssetRelativePath = EditorLMDirectoryPath + "/" + AssetName + ".uasset";
+	const FString LanguageModelAssetFullPath = FPaths::ConvertRelativePathToFull(LanguageModelAssetRelativePath);
+	if (PlatformFile.FileExists(*LanguageModelAssetFullPath))
+	{
+		return DownloadFuture;
+	}
+
 	return DownloadFuture.Next([this, EditorLMFilePathFull, AssetName = MoveTemp(AssetName), PackagePath = MoveTemp(PackagePath), AssetPath = MoveTemp(AssetPath)](bool bDownloadSucceeded) mutable
 	{
 		if (!bDownloadSucceeded)


### PR DESCRIPTION
This pull request addresses issue mentioned in #15 and fixes it by checking if a language model already exists in the content directory of the plugin or not. If it already exists we just early return from the function and we do not attempt to create the asset again. Otherwise proceed as usual.